### PR TITLE
Specify encoding when writing the json data in create_data

### DIFF
--- a/create_data.py
+++ b/create_data.py
@@ -242,7 +242,7 @@ class DataProcessor:
 
     def _process_without_timestamps(self) -> None:
         records = []
-        with open(self.data_file) as f:
+        with open(self.data_file, encoding="utf-8") as f:
             for line in f:
                 audio_path, text = line.strip().split("\t")
                 if self.normalize_unicode:
@@ -296,7 +296,7 @@ class DataProcessor:
         transcript_path: Union[str, Path], normalize_unicode: bool = False
     ) -> List[Utterance]:
         utterances = []
-        with open(transcript_path) as f:
+        with open(transcript_path, encoding="utf-8") as f:
             lines = f.readlines()
             timestamps_indices = [i for i, line in enumerate(lines) if " --> " in line]
             timestamps_indices.append(len(lines) + 1)  # a dummy index to make the loop below simple
@@ -331,7 +331,7 @@ class DataProcessor:
         transcript_path: Union[str, Path], normalize_unicode: bool = False
     ) -> List[Utterance]:
         utterances = []
-        with open(transcript_path) as f:
+        with open(transcript_path, encoding="utf-8") as f:
             lines = f.readlines()
             timestamps_indices = [i for i, line in enumerate(lines) if " --> " in line]
             timestamps_indices.append(len(lines) + 1)  # a dummy index to make the loop below simple
@@ -547,7 +547,7 @@ class DataProcessor:
     @staticmethod
     def read_records(path: Union[str, Path]) -> List[Record]:
         records = []
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 data = json.loads(line)
                 record = Record(

--- a/create_data.py
+++ b/create_data.py
@@ -561,7 +561,7 @@ class DataProcessor:
 
     @staticmethod
     def write_records(records: List[Record], path: Union[str, Path]) -> None:
-        with open(path, "a") as f:
+        with open(path, "a", encoding="utf-8") as f:
             for record in records:
                 data = {
                     "audio_path": record.audio_path,

--- a/run_finetuning.py
+++ b/run_finetuning.py
@@ -180,7 +180,7 @@ def set_seed(seed: int):
 
 
 def save_args(args: argparse.Namespace, path: str) -> None:
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         f.write(json.dumps(vars(args), indent=4, ensure_ascii=False))
 
 

--- a/transcribe.py
+++ b/transcribe.py
@@ -53,7 +53,7 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def save_srt(transcript: Iterator[dict], path: Union[str, Path]) -> None:
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         write_srt(transcript, file=f)
 
 


### PR DESCRIPTION
In Windows I think this fails because it uses cp1252 encoding by default. By specifying the UTF-8 in the open function it solves the problem.

This is the error I get without the change.

```
Traceback (most recent call last):
  File "D:\ai\whisper-finetuning\create_data.py", line 609, in <module>
    main()
  File "D:\ai\whisper-finetuning\create_data.py", line 605, in main
    processor.run()
  File "D:\ai\whisper-finetuning\create_data.py", line 236, in run
    self._process_with_timestamps()
  File "D:\ai\whisper-finetuning\create_data.py", line 292, in _process_with_timestamps
    self.write_records(records, self.output)
  File "D:\ai\whisper-finetuning\create_data.py", line 572, in write_records
    f.write(json.dumps(data, ensure_ascii=False) + "\n")
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.2800.0_x64__qbz5n2kfra8p0\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f451' in position 67: character maps to <undefined>
```