### PR TITLE
Fix VTT timestamp parsing and broken --without-timestamps flag

### DIFF
--- a/create_data.py
+++ b/create_data.py
@@ -29,7 +29,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--without-timestamps",
         action="store_false",
-        dest="with-timestamps",
+        dest="with_timestamps",
         help=(
             "Read a text file containing audio filenames and transcriptions to create a jsonl file "
             "without timestamps and prompts. This will be used for fine-tuning a Whisper model "
@@ -500,7 +500,18 @@ class DataProcessor:
             raise ValueError(
                 f"Invalid time format: {s}. Must be in the format of 00:00:00,000 or 00:00:00.000"
             )
-        hours, minutes, seconds = time.split(":")
+        # WebVTT timestamps may omit the hours field when it is zero (e.g. "00:05.000"),
+        # which is how Whisper's own VTT writer formats segments shorter than one hour.
+        time_parts = time.split(":")
+        if len(time_parts) == 3:
+            hours, minutes, seconds = time_parts
+        elif len(time_parts) == 2:
+            hours, (minutes, seconds) = "0", time_parts
+        else:
+            raise ValueError(
+                f"Invalid time format: {s}. Must be in the format of 00:00:00,000, "
+                "00:00:00.000 or 00:00.000"
+            )
         hours = int(hours)
         minutes = int(minutes)
         seconds = int(seconds)


### PR DESCRIPTION
Fixes two independent bugs in `create_data.py`, found by comparing the implementation against Whisper's own code.

## What changed

### 1. `str_to_milliseconds` could not parse Whisper-generated VTT files
The function unpacked `time.split(":")` into three parts, assuming an `HH:MM:SS` time field. But Whisper's own `WriteVTT` formats segments shorter than one hour as `MM:SS.mmm` (its `format_timestamp` defaults to `always_include_hours=False`). Reading such a VTT file therefore raised `ValueError: not enough values to unpack`.

Now both `HH:MM:SS` and `MM:SS` time fields are accepted. This also unblocks `read_utterances_from_vtt` and `calculate_metric.py`'s `vtt_to_text`, which depend on it.

### 2. `--without-timestamps` flag had no effect
The argument used `dest="with-timestamps"` (with a hyphen). argparse stored that as a separate, unused attribute, leaving `args.with_timestamps` at its `True` default — so passing `--without-timestamps` did nothing. Changed `dest` to `with_timestamps` so the flag correctly toggles the value.

## Why
Both deviate from how Whisper itself produces/consumes data, and #2 silently disabled a documented CLI flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)