### PR TITLE
Fix data preparation and dataloader bugs

### DIFF
--- a/create_data.py
+++ b/create_data.py
@@ -29,7 +29,7 @@ def get_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--without-timestamps",
         action="store_false",
-        dest="with-timestamps",
+        dest="with_timestamps",
         help=(
             "Read a text file containing audio filenames and transcriptions to create a jsonl file "
             "without timestamps and prompts. This will be used for fine-tuning a Whisper model "
@@ -299,7 +299,10 @@ class DataProcessor:
         with open(transcript_path, encoding="utf-8") as f:
             lines = f.readlines()
             timestamps_indices = [i for i, line in enumerate(lines) if " --> " in line]
-            timestamps_indices.append(len(lines) + 1)  # a dummy index to make the loop below simple
+            # a dummy index to make the loop below simple; +2 so that the text of the last
+            # utterance spans until the end of the file even when the file does not end with
+            # a blank line
+            timestamps_indices.append(len(lines) + 2)
 
             for i in range(len(timestamps_indices) - 1):
                 utterance_start = timestamps_indices[i]
@@ -377,6 +380,9 @@ class DataProcessor:
                 utterances[idx].start < segment_end
                 and utterances[idx].start + DURATION < utterances[idx].end
             ):
+                # The skipped utterance breaks the continuity of the transcript, so the buffered
+                # prompt must not be used for the following segments
+                prompt_buffer.clear()
                 segment_start = utterances[idx].end
                 segment_end = segment_start + DURATION
                 idx += 1
@@ -490,7 +496,8 @@ class DataProcessor:
     @staticmethod
     def str_to_milliseconds(s: str) -> int:
         """
-        Convert a string in the format of "00:00:00,000" to milliseconds.
+        Convert a string in the format of "00:00:00,000" (or "00:00:00.000") to milliseconds.
+        The hours part may be omitted (e.g. "00:00.000"), as allowed in the WebVTT format.
         """
         if "," in s:
             time, miliseconds = s.split(",")
@@ -500,7 +507,16 @@ class DataProcessor:
             raise ValueError(
                 f"Invalid time format: {s}. Must be in the format of 00:00:00,000 or 00:00:00.000"
             )
-        hours, minutes, seconds = time.split(":")
+        time_parts = time.split(":")
+        if len(time_parts) == 3:
+            hours, minutes, seconds = time_parts
+        elif len(time_parts) == 2:
+            hours = "0"
+            minutes, seconds = time_parts
+        else:
+            raise ValueError(
+                f"Invalid time format: {s}. Must be in the format of 00:00:00,000 or 00:00.000"
+            )
         hours = int(hours)
         minutes = int(minutes)
         seconds = int(seconds)

--- a/dataloader.py
+++ b/dataloader.py
@@ -83,10 +83,12 @@ class AudioDataset(Dataset):
 
     def _get_partial_segment_start(self, tokens: List[int]) -> Optional[float]:
         if (
-            len(tokens) >= 2
-            and tokens[-2] >= self.tokenizer.timestamp_begin
+            len(tokens) >= 1
             and tokens[-1] >= self.tokenizer.timestamp_begin
+            and (len(tokens) == 1 or tokens[-2] >= self.tokenizer.timestamp_begin)
         ):  # if the last token is a start time token
+            # A start time token is either preceded by an end time token or is the only token
+            # (i.e., the segment contains nothing but the beginning of a partial utterance)
             return (tokens[-1] - self.tokenizer.timestamp_begin) * 0.02
         else:
             return None

--- a/run_finetuning.py
+++ b/run_finetuning.py
@@ -4,7 +4,7 @@ import json
 import random
 from dataclasses import asdict
 from pathlib import Path
-from typing import Iterator, Tuple
+from typing import Iterator
 
 import numpy as np
 import torch
@@ -131,7 +131,7 @@ def train_step(
     accum_grad_steps: int,
     train_only_decoder: bool,
     max_grad_norm: float,
-) -> Tuple[float, Iterator]:
+) -> float:
     model.train()
     total_loss = 0
     for _ in range(accum_grad_steps):


### PR DESCRIPTION
## What changed

This PR fixes five bugs found while auditing the implementation against the Whisper paper and the official implementation, plus one type annotation.

### `create_data.py`

- **`--without-timestamps` had no effect.** The flag used `dest="with-timestamps"` (hyphen), so it set a `with-timestamps` attribute while the code reads `args.with_timestamps`, which stayed `True`. Utterance-by-utterance training mode was effectively unreachable from the CLI.
- **The last subtitle of an SRT file was silently dropped** when the file does not end with a blank line (a common way for SRT files to end). The dummy end index is now `len(lines) + 2` so the final cue's text spans to the end of the file; files that do end with a blank line still parse identically.
- **WebVTT timestamps without the hours part (`MM:SS.mmm`) crashed `str_to_milliseconds`.** The VTT spec allows omitting hours, and tools like YouTube produce such files. Both 2- and 3-part time formats are now accepted.
- **Skipping an utterance longer than 30s left stale text in the prompt buffer**, producing prompts that are not contiguous with the current segment. This contradicts the paper's conditioning on "the transcript text preceding the current audio segment", and the other skip path (invalid utterances) already clears the buffer. The buffer is now cleared here too.

### `dataloader.py`

- **Segments containing only a partial utterance were trained as no-speech over audio that contains speech.** When a segment's text is a single start timestamp token (an utterance that starts mid-segment and extends past the 30s boundary), `_get_partial_segment_start` required at least two tokens and returned `None`. In no-timestamps mode the timestamp was then filtered out, the text became empty, and the sample was labeled `<|nospeech|>` with the full untrimmed 30s audio — a wrong training signal for the paper's voice-activity-detection task. The single-token case is now detected (the first token of a segment is always a start token), so the mel is trimmed to the partial utterance start and the remaining audio is genuinely non-speech.

### `run_finetuning.py`

- Fixed `train_step`'s return type annotation (`Tuple[float, Iterator]` → `float`, matching what it returns).

## How this was verified

Each fix was exercised directly: argparse parsing with and without the flag; SRT parsing across four file-ending variants (trailing blank line, trailing newline only, no trailing newline, multi-line final cue); VTT parsing with hour-less timestamps plus `str_to_milliseconds` regressions; `_get_partial_segment_start` on single-token, multi-utterance-partial, end-token-final, and empty inputs; and decoder input/output alignment (one-token shift, `-100` prompt masking, no-speech format) with and without prompts.

## Notes for reviewers

- Aspects checked against the paper and left unchanged: special token order, prompt loss masking (SOT prediction intentionally kept), `<|sot|><|nospeech|><|eot|>` format for silence, partial utterances predicting only their start token.
- Not addressed here: training runs fully in fp16 without dynamic loss scaling (the paper uses fp16 *with* dynamic loss scaling), which can underflow gradients on larger models. Fixing that requires reworking the training loop, so it's left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)